### PR TITLE
Fix of #4 (Corrects Exercise 6)

### DIFF
--- a/doc/sta_basics_course.rst
+++ b/doc/sta_basics_course.rst
@@ -833,14 +833,14 @@ After identifying the worst case conditions we obtain the following slacks::
     G1/A                2       25                          G2/A                2       15
     FF2/D               0       25                          FF2/D               0       15
     data arrive                 25                          data arrive                 15
-    
-    clkb (rise)         0       30   <-- capture time -->   clkb (rise)         0        7.5
-    FF2/CK              0       30                          FF2/CK              0        7.5
-    FF2 setup          -0.7     29.3                        FF2 hold            0.3      7.8
-    data required               29.3                        data required                7.8
-    
-    slack (required - arrive)    4.3 > 0                    slack (required - arrive)   -7.2 < 0
-    => setup check passed                                   => hold check passed
+
+    clkb (rise)         0       22.5 <-- capture time -->   clkb (rise)         0        7.5
+    FF2/CK              0       22.5                        FF2/CK              0        7.5
+    FF2 setup          -0.7     21.8                        FF2 hold            0.3      7.8
+    data required               21.8                        data required                7.8
+
+    slack (required - arrive)    -3.2 < 0                   slack (required - arrive)   -7.2 < 0
+    => setup check failed                                   => hold check passed
 
 Obviously the multi-clock exercise is about expanding the clock waveforms. Below there are two
 more examples with clock periods of 10 ns and 30 ns and different phase alignment.


### PR DESCRIPTION
Corresponding PrimeTime report is as follows:

```
  Point                                    Incr       Path
  ---------------------------------------------------------------
  clock CLKA (rise edge)                  20.00      20.00
  clock network delay (ideal)              0.00      20.00
  FF1/CK (dffrx1)                          0.00      20.00 r
  FF1/Q (dffrx1)                           3.00      23.00 f
  G1/Y (invx1)                             2.00      25.00 r
  FF2/D (dffrx1)                           0.00      25.00 r
  data arrival time                                  25.00

  clock CLKB (rise edge)                  22.50      22.50
  clock network delay (ideal)              0.00      22.50
  clock reconvergence pessimism            0.00      22.50
  FF2/CK (dffrx1)                                    22.50 r
  library setup time                      -0.70      21.80
  data required time                                 21.80
  ---------------------------------------------------------------
  data required time                                 21.80
  data arrival time                                 -25.00
  ---------------------------------------------------------------
  slack (VIOLATED)                                   -3.20
```